### PR TITLE
Release v0.3.1: maintained evidence workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           $cfdpaper = Join-Path $smoke "Scripts\cfdpaper.exe"
           & $smokePython -m pip install --no-cache-dir $wheel.FullName
           Set-Location $env:RUNNER_TEMP
-          & $smokePython -c "import importlib.metadata as m, pathlib, sys; import cfdpaper; import cfdpaper.topic_generation; root=pathlib.Path(sys.prefix).resolve(); module=pathlib.Path(cfdpaper.__file__).resolve(); dist=m.distribution('cfd-paper-agent'); files=tuple(item.as_posix() for item in (dist.files or ())); assert module.is_relative_to(root), (module, root); assert dist.version == cfdpaper.__version__ == '0.3.0'; assert any(item.endswith('licenses/LICENSE') for item in files), files; assert any(item.endswith('licenses/NOTICE') for item in files), files; print(module)"
+          & $smokePython -c "import importlib.metadata as m, pathlib, sys; import cfdpaper; import cfdpaper.topic_generation; root=pathlib.Path(sys.prefix).resolve(); module=pathlib.Path(cfdpaper.__file__).resolve(); dist=m.distribution('cfd-paper-agent'); files=tuple(item.as_posix() for item in (dist.files or ())); assert module.is_relative_to(root), (module, root); assert dist.version == cfdpaper.__version__ == '0.3.1'; assert any(item.endswith('licenses/LICENSE') for item in files), files; assert any(item.endswith('licenses/NOTICE') for item in files), files; print(module)"
           & $cfdpaper --help
           New-Item -ItemType Directory -Path $project | Out-Null
           [IO.File]::WriteAllText(
@@ -120,6 +120,6 @@ jobs:
       - name: Upload release distributions
         uses: actions/upload-artifact@v4
         with:
-          name: cfd-paper-agent-0.3.0-distributions
+          name: cfd-paper-agent-0.3.1-distributions
           path: ${{ runner.temp }}/cfdpaper-dist/*
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-09-04
+
+### Fixed
+
+- Made CLI help assertions deterministic when continuous-integration terminals emit ANSI styling.
+- Corrected a line-ending-sensitive stale-source regression so Linux and Windows test the same
+  scientific-input change.
+- Updated release-package formatting and version checks so the wheel smoke test runs consistently
+  across the supported matrix.
+
+### Documentation
+
+- Aligned the README, architecture, limitations, roadmap, release notes, and documentation index
+  with the evidence-to-figure-and-paragraph workflow delivered in v0.3.
+
 ## [0.3.0] — 2026-09-04
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: >-
   If you use CFD-Paper-Agent, please cite the software metadata for the version you used.
 title: CFD-Paper-Agent
 type: software
-version: "0.3.0"
+version: "0.3.1"
 date-released: 2026-09-04
 authors:
   - name: bluesarrow

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # CFD-Paper-Agent
 
+[![CI](https://github.com/Xiuyiw/CFD-SCIPaper-Agent/actions/workflows/ci.yml/badge.svg)](https://github.com/Xiuyiw/CFD-SCIPaper-Agent/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/Xiuyiw/CFD-SCIPaper-Agent)](https://github.com/Xiuyiw/CFD-SCIPaper-Agent/releases/latest)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+
 CFD-Paper-Agent is an open-source, author-in-the-loop workflow for turning mature CFD evidence into
-defensible paper topics, figures, and results prose. Version 0.3.0 adds a complete evidence pathway:
+defensible paper topics, figures, and results prose. Version 0.3.1 provides the maintained v0.3
+evidence pathway:
 qualify a declared comparison, lock a quantity of interest (QoI), analyze discrete cases, render an
 evidence-bound figure, and write one numerically backlinked results paragraph.
 
@@ -20,7 +25,7 @@ the QoI and figure claim, and approve the final artifact.
 | Evidence writing | Available | One results paragraph with numeric backlinks and an author-approved reporting ceiling. |
 | Guided scientific intake | Experimental | Interactive alternative to an existing `project-records.json` envelope. |
 | Native Fluent, STAR-CCM+, and other solver ingestion | Roadmap | Export structured neutral inputs for this release. |
-| Full-manuscript writing, literature management, review, revision, and document export | Roadmap | Not delivered by the v0.3.0 CLI. |
+| Full-manuscript writing, literature management, review, revision, and document export | Roadmap | Not delivered by the v0.3.1 CLI. |
 
 ## Installation
 
@@ -31,7 +36,7 @@ python -m pip install -e .
 cfdpaper --help
 ```
 
-## Reproducible v0.3.0 Quickstart
+## Reproducible v0.3.1 Quickstart
 
 Copy `examples/steady_laminar_pipe` to a writable directory and change into the copied directory.
 The example uses synthetic, non-sensitive data for fully developed laminar pipe flow.
@@ -123,7 +128,7 @@ automatically to verified scientific evidence.
 
 ## Explicit non-capabilities
 
-Version 0.3.0 does not run CFD simulations, ingest arbitrary native solver cases, infer missing
+Version 0.3.1 does not run CFD simulations, ingest arbitrary native solver cases, infer missing
 values, construct undeclared spatial integrals, smooth discrete cases into a continuous response,
 identify an operating optimum, write a complete manuscript, manage references, export submission
 documents, or submit to a journal. The `review`, `revise`, and `export` commands remain unavailable.
@@ -133,6 +138,8 @@ documents, or submit to a journal. The `review`, `revise`, and `export` commands
 - [Documentation index](docs/README.md)
 - [Architecture overview](docs/architecture/overview.md)
 - [Roadmap](docs/ROADMAP.md)
+- [v0.3.1 release notes](docs/releases/v0.3.1.md)
+- [v0.3.0 release notes](docs/releases/v0.3.0.md)
 - [v0.2.0 release notes](docs/releases/v0.2.0.md)
 - [v0.1.0 release notes](docs/releases/v0.1.0.md)
 - [Limitations](docs/limitations.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@
   topic file.
 - [Generated-topic walkthrough](../examples/generated-topic/README.md): create mature synthetic
   records and generate evidence-bounded topic candidates.
+- [Evidence-to-figure walkthrough](../examples/steady_laminar_pipe/README.md): qualify a comparison,
+  analyze a QoI, produce a figure package, and write a numerically linked results paragraph.
 - [Architecture overview](architecture/overview.md): understand project state, evidence records,
   planning, and author approval.
 
@@ -18,6 +20,8 @@
 
 ## Releases
 
+- [v0.3.1](releases/v0.3.1.md)
+- [v0.3.0](releases/v0.3.0.md)
 - [v0.2.0](releases/v0.2.0.md)
 - [v0.1.0](releases/v0.1.0.md)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,11 +8,28 @@ recorded here instead of being represented as already complete.
 
 ## Versioned delivery
 
-| Version | Public deliverable | Release condition |
+| Version | Public deliverable | Status |
 |---|---|---|
-| `v0.1.0` | Initial Public Preview: installable CLI, local project state, resumable inspection, and author-supplied topic ranking | Released 2026-08-30 |
-| `v0.2.0` | Automatic generation of 2–4 evidence-bounded topic candidates from mature structured records | Public positive example, fail-closed private challenge replays, CI, package, and release smoke pass |
-| `v0.3.0` | Paused; no active specification, branch, or implementation | Development resumes only after explicit author authorization |
+| `v0.1.0` | Installable CLI, local project state, resumable inspection, and author-supplied topic ranking | Released 2026-08-30 |
+| `v0.2.0` | Automatic generation of 2–4 evidence-bounded topic candidates from mature structured records | Released 2026-08-31 |
+| `v0.3.0` | Structured comparison qualification, discrete QoI analysis, one reproducible figure, and one numerically backlinked results paragraph | Released 2026-09-04 |
+| `v0.3.1` | Cross-platform CI and public-documentation maintenance for the v0.3 workflow | Current release |
+| Next capability release | One author-approved product bottleneck selected after the v0.3 workflow review | Specification pending |
+
+## Product direction
+
+Development follows the path from mature CFD results to an author-approved scientific paper:
+
+1. solver-neutral and solver-assisted result intake;
+2. scientific comparison, QoI, trend, uncertainty, and field analysis;
+3. publication figures and linked scientific writing;
+4. full paper structure and document export;
+5. pre-submission review and event-driven revision after real reviewer comments;
+6. heterogeneous validation across flow, heat-transfer, and multiphase projects.
+
+The next release will narrow this list to one primary user bottleneck before implementation. This
+keeps each public increment useful and testable without presenting the long-term system as already
+complete.
 
 ## Long-term maturity gates
 
@@ -25,8 +42,8 @@ recorded here instead of being represented as already complete.
 | 4 | Analysis, figures, writing and export | Claims remain evidence-linked and artifacts are real |
 | 5 | Pre-submission review and event-driven revision | No planned or synthetic change is reported as complete |
 | 6 | Three heterogeneous real-project validations | Zero hard scientific and cross-document errors |
-| 7 | Stable public package | CI, docs, examples, license and release audit pass |
+| 7 | Stable public package | CI, docs, examples, license and release checks pass |
 
-The versioned roadmap changes when functionality becomes public; it does not weaken the maturity
-gates. Development pauses after v0.2.0. Longer-term gates remain architectural context rather than
-an active backlog, and no v0.3.0 work begins without explicit author authorization.
+These maturity gates describe the route to a broadly reusable product. They do not imply that the
+current release already supports arbitrary solver files, complete manuscripts, or unattended
+research decisions.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,50 +1,56 @@
 # Architecture overview
 
 CFD-Paper-Agent keeps project state local and separates file discovery from scientific evidence
-qualification. In v0.2.0, the CLI coordinates source indexing, structured scientific records,
-evidence-bounded topic generation or author-supplied candidates, ranking, and explicit author
-approval.
+qualification. In v0.3.1, the public workflow connects mature structured CFD evidence to a bounded
+research direction, an approved quantity of interest (QoI), a discrete analysis, one reproducible
+figure, and one results paragraph.
 
 ```mermaid
 flowchart LR
     A[Mature CFD results or neutral exports] --> B[inspect]
-    B --> C[Local source index and staleness state]
-    C --> D[Structured scientific records]
-    D --> E[Evidence and claim-ceiling checks]
-    F[Author candidate file] --> G[plan]
-    E --> H[Generate 2–4 provisional candidates]
-    H --> G
-    G --> I[Ranked report and recoverable artifacts]
-    I --> J{Author review and approval}
-    J -. paused roadmap .-> K[analyze → figure → write]
+    B --> C[Local source index and stale state]
+    C --> D[Structured cases, observations, and checks]
+    D --> E[qualify comparison and candidate QoI]
+    E --> F[plan 2–4 provisional topics]
+    F --> G{Author selects topic}
+    G --> H{Author locks QoI}
+    H --> I[analyze observed discrete cases]
+    I --> J{Author accepts figure contract}
+    J --> K[figure package]
+    K --> L[write results paragraph]
+    L --> M{Author approves final artifact}
 ```
 
-`inspect` records relative source URIs, content identity, and stale/current state. It does not infer
-solver semantics or promote files to evidence. Structured case, boundary, QoI, convergence,
-conservation, and provenance records must be supplied through current Python contracts or an
-adapter that preserves their source locators.
+`inspect` records relative source locations and detects changed inputs. It does not infer solver
+semantics or treat file presence as scientific validation.
 
-`plan` performs a fast incremental reinspection. When an author candidate file is supplied, it is
-validated and ranked. Otherwise the planner discovers comparison and ordered-response
-opportunities from mature structured records, constructs two to four provisional candidates, and
-records supporting evidence, prohibited inferences, claim ceilings, and minimum missing data.
-Missing evidence is a valid result rather than a hidden success.
+`qualify` checks the declared comparison, case membership, units, source locations, convergence,
+conservation, verification, validation, and proposed QoI. The current public interface expects
+structured records and scalar observations rather than arbitrary native solver files.
 
-Offline generation is deterministic. Optional provider refinement may change bounded wording but
-cannot introduce evidence, alter numerical relations, or approve a topic. Candidate generation
-artifacts are committed atomically to the project-local `.cfdpaper` directory and reused only while
-their scientific inputs remain current.
+`plan` ranks an author candidate file or generates two to four provisional directions from mature
+records. Offline generation is deterministic. Optional provider refinement may improve bounded
+wording but cannot add evidence, alter numerical relations, or approve a topic.
+
+After author selection, the QoI is locked before `analyze` reads the declared discrete sequence.
+The analysis records trends and claim ceilings without interpolation, smoothing, or continuous
+optimization. `figure` packages source data, a runnable plotting script, editable and preview
+graphics, a caption, and focused QA results. `write` produces one results paragraph whose numbers
+link back to the analyzed records.
 
 ## Local components
 
 | Component | Responsibility | Boundary |
 |---|---|---|
-| Typer CLI | Expose current commands and non-zero roadmap placeholders | No unattended research decisions |
-| Project indexer | Discover files, cache bytes, and track staleness | No scientific evidence qualification |
-| SQLite store | Persist project, sources, evidence, QoI definitions, assessments, and checkpoints | Local state; author controls source data |
-| Topic generator | Discover bounded opportunities and construct provisional candidates | No evidence invention or automatic approval |
-| Planner | Rank generated or author-supplied candidates and write reports | Author approves the final direction |
+| Typer CLI | Coordinate the public workflow and report unavailable commands clearly | No unattended research decisions |
+| Project indexer | Discover files and track changed sources | No scientific evidence qualification |
+| SQLite store | Persist project state, sources, records, approvals, and checkpoints | Project-local state |
+| Topic planner | Propose and rank bounded research directions | Author selects the direction |
+| Scientific qualifier | Check comparability, evidence, QoI definition, and reporting limits | Missing evidence remains missing |
+| QoI analyzer | Evaluate declared scalar sequences and allowable trends | Observed discrete cases only |
+| Figure pipeline | Produce one evidence-linked figure package | No undeclared transformation or general field plotting |
+| Writing pipeline | Produce one numerically backlinked results paragraph | No complete manuscript or autonomous claim expansion |
 
-Analysis, figure generation, writing, review, revision, export, and general solver-native extraction
-are not delivered end to end in v0.2.0. Development pauses after this release until explicitly
-resumed. See the [public roadmap](../ROADMAP.md).
+Native Fluent and STAR-CCM+ extraction, general field analysis, multi-figure manuscript production,
+literature management, pre-submission review, reviewer-response workflows, and document export remain
+future work. See the [public roadmap](../ROADMAP.md) and [current limitations](../limitations.md).

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,25 +1,33 @@
 # Limitations
 
-CFD-Paper-Agent v0.2.0 is not a CFD solver and does not validate a model merely because result
-files exist. It cannot replace domain expertise, experimental validation, source-literature
-verification, or author responsibility.
+CFD-Paper-Agent v0.3.1 is not a CFD solver and does not validate a model merely because result files
+exist. It cannot replace domain expertise, experimental validation, source-literature verification,
+or author responsibility.
 
-The public CLI supports `init`, `status`, `inspect`, and `plan`. `plan` can rank author-supplied
-candidates or generate provisional candidates when mature structured scientific records already
-exist. Inspection creates a source index, not verified scientific evidence, and v0.2.0 has no
-general CLI that converts arbitrary CFD or CSV files into complete case, boundary, convergence,
-conservation, QoI-definition, and QoI records.
+The public CLI supports `init`, `status`, `inspect`, `plan`, `qualify`, `analyze`, `figure`, and
+`write`. The implemented scientific path expects structured case records, located scalar
+observations, a declared comparison, and a proposed QoI. It does not convert arbitrary Fluent,
+STAR-CCM+, or other native solver files into complete scientific records. Guided intake is
+experimental and still requires the author to supply the scientific meaning of the data.
 
-Generated candidates are limited by current comparability, units, convergence, conservation,
-QoI definitions, provenance, and claim ceilings. Missing evidence yields a missing-data result;
-author approval cannot override a failed scientific gate. Generated JSON artifacts are recoverable
-project state, not a stable public interchange contract.
+Qualification can reject incomplete membership, unknown units, incompatible cases, missing source
+locations, or inadequate convergence, conservation, verification, and validation evidence. Passing
+these checks bounds what the software may report; it does not make a physical interpretation true.
 
-The `analyze` through `export` commands remain roadmap placeholders. They exit non-zero and do not
-produce completed workflow artifacts. Native Fluent, STAR-CCM+, or other solver integration is not
-a general v0.2.0 capability; optional adapters and provider interfaces remain extension points.
+Analysis is limited to the declared observations and discrete cases. The current release does not
+construct undeclared spatial or temporal integrals, infer missing values, smooth sparse cases,
+identify a continuous optimum, quantify a general uncertainty envelope, or perform general
+three-dimensional field analysis.
+
+Figure production delivers one evidence-bound panel with source data, a runnable Matplotlib script,
+SVG and PNG output, a caption, and focused QA records. It is not yet a general contour, profile,
+multi-panel, TIFF, or manuscript-assembly system. Writing produces one results paragraph with
+numeric backlinks; it does not yet create a full manuscript, manage literature, or export DOCX or
+LaTeX submission packages.
+
+The `review`, `revise`, and `export` commands remain unavailable. Reviewer-response work must be
+triggered by real reviewer comments, and journal submission remains an author action.
 
 Discrete CFD screening must not be presented as an experimental operating window, continuous
-optimum, safety boundary, or validation claim. Topic approval remains an author action and does
-not authorize manuscript production, journal submission, appeals, or external communication.
-
+optimum, safety boundary, or validation claim. Author approval selects a reporting direction within
+the available evidence; it cannot override missing or failed scientific support.

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,28 @@
+# CFD-Paper-Agent v0.3.0 — Evidence to figure and results prose
+
+Released: 2026-09-04
+
+v0.3.0 adds the first public vertical path from mature structured CFD evidence to a reproducible
+scientific artifact. Authors can qualify a declared comparison, lock a scalar QoI, analyze observed
+discrete cases, approve a figure contract, generate a figure package, and approve one numerically
+backlinked results paragraph.
+
+## Added
+
+- strict case, boundary, observation, unit, source-location, convergence, conservation,
+  verification, and validation records;
+- comparison qualification and author-locked QoI contracts;
+- discrete trend analysis with reporting ceilings that prohibit unsupported interpolation or
+  continuous optimization;
+- a reproducible figure package containing source data, a runnable script, SVG, PNG, caption, and
+  focused data, narrative, and visual checks;
+- one results paragraph whose quantitative statements link to analyzed observations;
+- a synthetic laminar-pipe example with positive and negative variants.
+
+## Boundary
+
+The release expects structured neutral inputs. It does not ingest arbitrary native solver cases,
+perform general field analysis, create a complete manuscript, manage references, review or revise a
+paper, export submission documents, or submit to a journal.
+
+Use v0.3.1 or later for the maintained v0.3 workflow and corrected cross-platform release checks.

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,0 +1,28 @@
+# CFD-Paper-Agent v0.3.1 — Maintained evidence workflow
+
+Released: 2026-09-04
+
+v0.3.1 is a maintenance release for the evidence-to-figure-and-results workflow introduced in
+v0.3.0. It does not change scientific algorithms or broaden the product claim.
+
+## Fixed
+
+- CLI help tests now compare visible text consistently when CI terminals emit ANSI styling.
+- The stale-source regression changes a scientific value explicitly, so Linux and Windows exercise
+  the same behavior without depending on line-ending conversion.
+- The release-package format check and version smoke test now complete consistently across the
+  supported Python and operating-system matrix.
+
+## Documentation
+
+- The README, architecture, limitations, roadmap, documentation index, changelog, citation metadata,
+  and release notes now describe the current public workflow consistently.
+- Historical research documents and earlier release notes remain unchanged as records of their own
+  baselines.
+
+## Current capability boundary
+
+The available CLI path is `init` → `inspect` → `qualify`/`plan` → `analyze` → `figure` → `write`,
+with explicit author decisions before topic, QoI, figure, and final-artifact promotion. Native solver
+ingestion, general field analysis, full-manuscript production, literature management, `review`,
+`revise`, and `export` remain future work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cfd-paper-agent"
-version = "0.3.0"
-description = "Author-in-the-loop planning from mature CFD evidence to defensible paper topics"
+version = "0.3.1"
+description = "Author-in-the-loop CFD evidence analysis, figure generation, and scientific writing"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/cfdpaper/__init__.py
+++ b/src/cfdpaper/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("cfd-paper-agent")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.3.0"
+    __version__ = "0.3.1"

--- a/src/cfdpaper/cli.py
+++ b/src/cfdpaper/cli.py
@@ -334,5 +334,5 @@ for _command_name in (
 ):
     app.command(
         _command_name,
-        help="Roadmap command; not available in v0.3.0.",
+        help="Roadmap command; not available in v0.3.1.",
     )(_placeholder_command(_command_name))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,9 +86,9 @@ def test_top_level_help_labels_unavailable_commands_as_roadmap() -> None:
     assert result.exit_code == 0, result.stdout
     normalized = " ".join(_plain_cli_text(result.stdout).split())
     for command in ("review", "revise", "export"):
-        assert f"{command} Roadmap command; not available in v0.3.0." in normalized
+        assert f"{command} Roadmap command; not available in v0.3.1." in normalized
     for command in ("qualify", "analyze", "figure", "write"):
-        assert f"{command} Roadmap command; not available in v0.3.0." not in normalized
+        assert f"{command} Roadmap command; not available in v0.3.1." not in normalized
 
 
 def prepared_cli_project(tmp_path: Path) -> ProjectStore:

--- a/tests/test_package_version.py
+++ b/tests/test_package_version.py
@@ -16,4 +16,4 @@ def test_source_tree_version_fallback_matches_release(monkeypatch) -> None:
     module.__spec__ = spec
     spec.loader.exec_module(module)
 
-    assert module.__version__ == "0.3.0"
+    assert module.__version__ == "0.3.1"

--- a/tests/test_public_quickstart.py
+++ b/tests/test_public_quickstart.py
@@ -89,7 +89,7 @@ def test_public_quickstart_sources_are_synthetic_and_path_independent() -> None:
             assert all(fragment not in text for fragment in forbidden_fragments)
 
 
-def test_public_docs_match_the_v030_capability_contract() -> None:
+def test_public_docs_match_the_v031_capability_contract() -> None:
     readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
     capability_section = readme.split("## Capability matrix", 1)[1].split("\n## ", 1)[0]
     state_cells = {
@@ -138,6 +138,8 @@ def test_public_docs_match_the_v030_capability_contract() -> None:
         "docs/README.md",
         "docs/architecture/overview.md",
         "docs/ROADMAP.md",
+        "docs/releases/v0.3.1.md",
+        "docs/releases/v0.3.0.md",
         "docs/releases/v0.2.0.md",
         "docs/releases/v0.1.0.md",
         "docs/limitations.md",
@@ -149,6 +151,7 @@ def test_public_docs_match_the_v030_capability_contract() -> None:
         assert (REPOSITORY_ROOT / target).is_file()
 
     changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "## [0.3.1] — 2026-09-04" in changelog
     assert "## [0.3.0] — 2026-09-04" in changelog
     assert "## [0.2.0] — 2026-08-31" in changelog
     assert "alpha" not in changelog.casefold()
@@ -156,7 +159,7 @@ def test_public_docs_match_the_v030_capability_contract() -> None:
     citation = yaml.safe_load((REPOSITORY_ROOT / "CITATION.cff").read_text(encoding="utf-8"))
     assert citation["cff-version"] == "1.2.0"
     assert citation["title"] == "CFD-Paper-Agent"
-    assert citation["version"] == "0.3.0"
+    assert citation["version"] == "0.3.1"
     assert citation["license"] == "Apache-2.0"
 
     workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
@@ -164,5 +167,6 @@ def test_public_docs_match_the_v030_capability_contract() -> None:
         assert operating_system in workflow
     for python_version in ('"3.10"', '"3.11"', '"3.12"'):
         assert python_version in workflow
-    assert "cfd-paper-agent-0.3.0-distributions" in workflow
+    assert "cfd-paper-agent-0.3.1-distributions" in workflow
+    assert "cfd-paper-agent-0.3.0-distributions" not in workflow
     assert "cfd-paper-agent-0.2.0-distributions" not in workflow


### PR DESCRIPTION
Align public documentation and package metadata with the delivered v0.3 workflow; preserve the cross-platform CI fixes.

Verification: 1061 passed, 2 skipped; Ruff and package smoke passed.