### PR TITLE
CI: use Node.js 24 GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
           - "3.12"
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -46,9 +46,9 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -118,7 +118,7 @@ jobs:
           & $smokePython (Join-Path $env:GITHUB_WORKSPACE "examples\generated-topic\prepare_project.py") $generatedProject
           & $cfdpaper plan $generatedProject --provider offline
       - name: Upload release distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cfd-paper-agent-0.3.1-distributions
           path: ${{ runner.temp }}/cfdpaper-dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the GitHub Actions checkout, Python setup, and artifact upload steps to their Node.js 24
+  releases.
+
 ## [0.3.1] — 2026-09-04
 
 ### Fixed


### PR DESCRIPTION
Remove the Node.js 20 deprecation warnings from the public workflow by upgrading the three official GitHub Actions to their Node.js 24 majors. No job, matrix, command, package, or scientific behavior changes.

Verification: workflow YAML and action majors verified; focused public-doc tests, Ruff, format check, and diff check passed.